### PR TITLE
Authentication impossible if all user don't have the same groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ the LDAP Authenticator can be used:
 Address of the LDAP Server to contact. Just use a bare hostname or IP,
 without a port name or protocol prefix.
 
-#### `LDAPAuthenticator.bind_dn_template` ####
+#### `LDAPAuthenticator.bind_dn_template` #####
 
 Template to use to generate the full dn for a user from the human readable
 username. For example, if users in your LDAP database have DN of the form
@@ -42,6 +42,22 @@ you would set this config item to be:
 
 ```
 c.LDAPAuthenticator.bind_dn_template = 'uid={username},ou=people,dc=wikimedia,dc=org'
+```
+
+The `{username}` is expanded into the username the user provides.
+
+** Or you can use the following options if the dn is not static :**
+
+#### `LDAPAuthenticator.use_search_dn` ####
+
+Search the user on the server to get the full dn
+
+#### `LDAPAuthenticator.search_dn_template` ####
+
+The template to use for searching the user on the server
+
+```
+c.LDAPAuthenticator.search_dn_template = '(&(cn={username}))'
 ```
 
 The `{username}` is expanded into the username the user provides.

--- a/ldapauthenticator/ldapauthenticator.py
+++ b/ldapauthenticator/ldapauthenticator.py
@@ -102,7 +102,7 @@ class LDAPAuthenticator(Authenticator):
         userdn = None
 
         # If no bind_dn found, get it from the server
-        if self.use_search_dn:
+        if self.use_search_dn or self.bind_dn_template == "":
             co = ldap3.Connection(server)
             self.log.debug('Try to get full dn from server %s' % self.server_address)
 


### PR DESCRIPTION
If the full dn is not complete with all group of an user, with my LDAP server configuration, the server refuse to authenticate the user. So if all users don't share exactly the same group, authentication is impossible for a part of users. Example:
User T is in group A, B and C.
User U is in group A, B, C and D.
If the bind_dn_template only referring to group A, B and C user T can authenticate whereas user U can not. Because group D is missing on his full dn.
So the trick is to search the user on the LDAP server to get his full dn and use it in replacement of the bind_dn_template.
