### PR TITLE
Add support for looking up the account DN post-bind

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,22 @@ the LDAP server. Highly recommended that this be left to `True`
 Port to use to contact the LDAP server. Defaults to 389 if no SSL
 is being used, and 636 is SSL is being used.
 
+#### `LDAPAuthenticator.lookup_dn` ####
+
+Whether to try a reverse lookup to obtain the user's DN.  Some LDAP servers,
+such as Active Directory, don't always bind with the true DN, so this allows
+us to discover it based on the username.
+
+#### `LDAPAuthenticator.user_search_base` ####
+
+Only used with `lookup_dn=True`.  Defines the search base for looking up users
+in the directory.
+
+#### `LDAPAuthenticator.user_attribute` ####
+
+Only used with `lookup_dn=True`.  Defines the attribute that stores a user's
+username in your directory.
+
 ## Compatibility ##
 
 This has been tested against an OpenLDAP server, with the client


### PR DESCRIPTION
For AD environments like ours, a user's DN is hard to programmatically generate.  However, MS lets you bind with a username of form 'DOMAIN\username' which is what we use for our template.  In order to test group membership, we have to look up their DN later.  We opted to go this route, rather than trying for the `memberOf` attribute, because that overlay isn't a guaranteed thing in the OpenLDAP world.