### PR TITLE
Fix "name 'Union' is not defined"

### DIFF
--- a/ldapauthenticator/ldapauthenticator.py
+++ b/ldapauthenticator/ldapauthenticator.py
@@ -3,7 +3,7 @@ import re
 
 from jupyterhub.auth import Authenticator
 from tornado import gen
-from traitlets import Unicode, Int, Bool, List
+from traitlets import Unicode, Int, Bool, List, Union
 
 
 class LDAPAuthenticator(Authenticator):


### PR DESCRIPTION
The `Union` constructor used for `bind_dn_template` was not imported, causing a runtime error.