### PR TITLE
Don't force TLS bind if not using SSL.

### DIFF
--- a/ldapauthenticator/ldapauthenticator.py
+++ b/ldapauthenticator/ldapauthenticator.py
@@ -281,7 +281,7 @@ class LDAPAuthenticator(Authenticator):
                 server,
                 user=self.escape_userdn_if_needed(userdn),
                 password=password,
-                auto_bind=ldap3.AUTO_BIND_TLS_BEFORE_BIND,
+                auto_bind=self.use_ssl and ldap3.AUTO_BIND_TLS_BEFORE_BIND or ldap3.AUTO_BIND_NO_TLS,
             )
             return conn
         


### PR DESCRIPTION
The current code in the ``authenticate()`` method does:

```
            conn = ldap3.Connection(
                server,
                user=self.escape_userdn_if_needed(userdn),
                password=password,
                auto_bind=ldap3.AUTO_BIND_TLS_BEFORE_BIND,
            )
```

The explicit setting of ``auto_bind`` to be ``ldap3.AUTO_BIND_TLS_BEFORE_BIND`` appears to be wrong because it is forcing TLS negotiation even if ``use_ssl`` option was ``False``.

When not using SSL, this results in the error:

```
    Traceback (most recent call last):
      File "/opt/app-root/lib/python3.5/site-packages/tornado/web.py", line 1512, in _execute
        result = yield result
      File "/opt/app-root/lib/python3.5/site-packages/jupyterhub/handlers/login.py", line 83, in post
        user = yield self.login_user(data)
      File "/opt/app-root/lib/python3.5/site-packages/jupyterhub/handlers/base.py", line 328, in login_user
        authenticated = yield self.authenticate(data)
      File "/opt/app-root/lib/python3.5/site-packages/jupyterhub/auth.py", line 227, in get_authenticated_user
        authenticated = yield self.authenticate(handler, data)
      File "/opt/app-root/lib64/python3.5/types.py", line 243, in wrapped
        coro = func(*args, **kwargs)
      File "/opt/app-root/lib/python3.5/site-packages/ldapauthenticator/ldapauthenticator.py", line 314, in authenticate
        conn = getConnection(userdn, username, password)
      File "/opt/app-root/lib/python3.5/site-packages/ldapauthenticator/ldapauthenticator.py", line 284, in getConnection
        auto_bind=ldap3.AUTO_BIND_TLS_BEFORE_BIND,
      File "/opt/app-root/lib/python3.5/site-packages/ldap3/core/connection.py", line 321, in __init__
        self.do_auto_bind()
      File "/opt/app-root/lib/python3.5/site-packages/ldap3/core/connection.py", line 336, in do_auto_bind
        self.open(read_server_info=False)
      File "/opt/app-root/lib/python3.5/site-packages/ldap3/strategy/sync.py", line 56, in open
        BaseStrategy.open(self, reset_usage, read_server_info)
      File "/opt/app-root/lib/python3.5/site-packages/ldap3/strategy/base.py", line 153, in open
        self.connection.do_auto_bind()
      File "/opt/app-root/lib/python3.5/site-packages/ldap3/core/connection.py", line 340, in do_auto_bind
        self.start_tls(read_server_info=False)
      File "/opt/app-root/lib/python3.5/site-packages/ldap3/core/connection.py", line 1215, in start_tls
        if self.server.tls.start_tls(self) and self.strategy.sync:  # for asynchronous connections _start_tls is run by the strategy
      File "/opt/app-root/lib/python3.5/site-packages/ldap3/core/tls.py", line 271, in start_tls
        raise LDAPStartTLSError(connection.last_error)
    ldap3.core.exceptions.LDAPStartTLSError: startTLS failed - unavailable
```

because it is perhaps triggering TLS connection against LDAP port 389, or may be because LDAPS port 636 is not working.

This PR changes the code to:

```
            conn = ldap3.Connection(
                server,
                user=self.escape_userdn_if_needed(userdn),
                password=password,
                auto_bind=self.use_ssl and ldap3.AUTO_BIND_TLS_BEFORE_BIND or ldap3.AUTO_BIND_NO_TLS,
            )
```

so that TLS binding is only requested if ``use_ssl`` is ``True``.

This eliminates the exception and is believed not to affect SSL behaviour, although didn't have a LDAP with working LDAPS port to test.

It is amending what was originally added for this in https://github.com/jupyterhub/ldapauthenticator/pull/46