### PR TITLE
Added option `normalize_username_function`

### DIFF
--- a/ldapauthenticator/ldapauthenticator.py
+++ b/ldapauthenticator/ldapauthenticator.py
@@ -208,7 +208,11 @@ class LDAPAuthenticator(Authenticator):
         None,
         config=True,
         help="""
-        TODO
+        If not `None`, the first element must be a Python callable, which is used to normalize the
+        supplied username before authentication. Other elements are ignored.
+
+        For example, normalize supplied usernames to lowercase:
+        `c.LDAPAuthenticator.normalize_username_function = [str.lower]`
         """
     )
 

--- a/ldapauthenticator/ldapauthenticator.py
+++ b/ldapauthenticator/ldapauthenticator.py
@@ -204,6 +204,20 @@ class LDAPAuthenticator(Authenticator):
         """
     )
 
+    normalize_username_function = List(
+        None,
+        config=True,
+        help="""
+        TODO
+        """
+    )
+
+    def normalize_username(self, username_supplied_by_user):
+        if self.normalize_username_function[0] is not None and callable(self.normalize_username_function[0]):
+            return self.normalize_username_function[0](username_supplied_by_user)
+        else:
+            return username_supplied_by_user
+
     def resolve_username(self, username_supplied_by_user):
         if self.lookup_dn:
             server = ldap3.Server(
@@ -285,6 +299,11 @@ class LDAPAuthenticator(Authenticator):
             )
             return conn
         
+        # Normalize username with a configurable function. Perform before the valid_username_regex matching
+        username = self.normalize_username(username)
+        if username is None:
+            return None
+
         # Protect against invalid usernames as well as LDAP injection attacks
         if not re.match(self.valid_username_regex, username):
             self.log.warn('username:%s Illegal characters in username, must match regex %s', username, self.valid_username_regex)


### PR DESCRIPTION
Hi,

I've added the option `normalize_username_function`. My use case is as follows:
* users should be able to use case-insensitive usernames
* the username passed on to LDAP and Jupyterhub should be lowercase.

The new option is implemented as a list. The first element should be a callable, other elements are ignored. The callable must take one argument (the supplied username) and return a 'normalized' username. Username normalization happens right before `valid_username_regex` check so the normalization has to pass this check.

Example:
`LDAPAuthenticator.normalize_username_function = [str.lower]`

The reason for using a list is that my traitlets version doesn't support a callable type. Is there a better way to enforce the option to be of type "callable"?

Are there any security to concerns with this approach?

Happy to receive feedback.