### PR TITLE
Fix resolved_username regex

### DIFF
--- a/ldapauthenticator/ldapauthenticator.py
+++ b/ldapauthenticator/ldapauthenticator.py
@@ -302,7 +302,7 @@ class LDAPAuthenticator(Authenticator):
         if resolved_username is None:
             return None
 
-        resolved_username = re.subn(r"[^\\],", r"\,", resolved_username)[0]
+        resolved_username = re.subn(r"([^\\]),", r"\1\,", resolved_username)[0]
 
         bind_dn_template = self.bind_dn_template
         if isinstance(bind_dn_template, str):


### PR DESCRIPTION
The fix in #68 wasn't correct as the regex will swallow the previous character:
```python
>>> re.subn(r"[^\\],", r"\,", "Hirschfeld, David")[0]
'Hirschfel\\, David'
```
...the workaround is to capture the swallowed character and reinsert it:
```python
>>> re.subn(r"([^\\]),", r"\1\,", "Hirschfeld, David")[0]
'Hirschfeld\\, David'
```
Not sure if that is the most elegant solution, but it does seem to fix the problem...