### PR TITLE
Lookup additional LDAP user info

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ If set to True, escape special chars in userdn when authenticating in LDAP.
 On some LDAP servers, when userdn contains chars like '(', ')', '\' authentication may fail when those chars
 are not escaped.
 
-#### `LDAPAuthenticator.user_info_attributes` ####
+#### `LDAPAuthenticator.auth_state_attributes` ####
 
 An optional list of attributes to be fetched for a user after login.
 If found these will be returned as `auth_state`.

--- a/README.md
+++ b/README.md
@@ -167,6 +167,11 @@ If set to True, escape special chars in userdn when authenticating in LDAP.
 On some LDAP servers, when userdn contains chars like '(', ')', '\' authentication may fail when those chars
 are not escaped.
 
+#### `LDAPAuthenticator.user_info_attributes` ####
+
+An optional list of attributes to be fetched for a user after login.
+If found these will be returned as `auth_state`.
+
 ## Compatibility ##
 
 This has been tested against an OpenLDAP server, with the client

--- a/ldapauthenticator/ldapauthenticator.py
+++ b/ldapauthenticator/ldapauthenticator.py
@@ -215,8 +215,7 @@ class LDAPAuthenticator(Authenticator):
     attributes = List(config=True, help="List of attributes to be searched")
 
     user_info_attributes = List(
-        config=True,
-        help="List of attributes to be returned in auth_state for a user"
+        config=True, help="List of attributes to be returned in auth_state for a user"
     )
 
     use_lookup_dn_username = Bool(
@@ -296,9 +295,8 @@ class LDAPAuthenticator(Authenticator):
         attrs = {}
         if self.user_info_attributes:
             found = conn.search(
-                userdn,
-                '(objectClass=*)',
-                attributes=self.user_info_attributes)
+                userdn, "(objectClass=*)", attributes=self.user_info_attributes
+            )
             if found:
                 attrs = conn.entries[0].entry_attributes_as_dict
         return attrs
@@ -427,15 +425,12 @@ class LDAPAuthenticator(Authenticator):
                 return None
 
         if not self.use_lookup_dn_username:
-            username = data['username']
+            username = data["username"]
 
         user_info = self.get_user_attributes(conn, userdn)
         if user_info:
-            self.log.debug('username:%s attributes:%s', username, user_info)
-            return {
-                'name': username,
-                'auth_state': user_info,
-            }
+            self.log.debug("username:%s attributes:%s", username, user_info)
+            return {"name": username, "auth_state": user_info}
         return username
 
 

--- a/ldapauthenticator/ldapauthenticator.py
+++ b/ldapauthenticator/ldapauthenticator.py
@@ -214,7 +214,7 @@ class LDAPAuthenticator(Authenticator):
 
     attributes = List(config=True, help="List of attributes to be searched")
 
-    user_info_attributes = List(
+    auth_state_attributes = List(
         config=True, help="List of attributes to be returned in auth_state for a user"
     )
 
@@ -293,9 +293,9 @@ class LDAPAuthenticator(Authenticator):
 
     def get_user_attributes(self, conn, userdn):
         attrs = {}
-        if self.user_info_attributes:
+        if self.auth_state_attributes:
             found = conn.search(
-                userdn, "(objectClass=*)", attributes=self.user_info_attributes
+                userdn, "(objectClass=*)", attributes=self.auth_state_attributes
             )
             if found:
                 attrs = conn.entries[0].entry_attributes_as_dict

--- a/ldapauthenticator/tests/test_ldapauthenticator.py
+++ b/ldapauthenticator/tests/test_ldapauthenticator.py
@@ -93,10 +93,10 @@ async def test_ldap_auth_search_filter(authenticator):
 
 
 async def test_ldap_auth_user_info_attributes(authenticator):
-    authenticator.user_info_attributes = ['employeeType']
+    authenticator.user_info_attributes = ["employeeType"]
     # proper username and password in allowed group
     authorized = await authenticator.get_authenticated_user(
         None, {"username": "fry", "password": "fry"}
     )
     assert authorized["name"] == "fry"
-    assert authorized["auth_state"] == {'employeeType': ['Delivery boy']}
+    assert authorized["auth_state"] == {"employeeType": ["Delivery boy"]}

--- a/ldapauthenticator/tests/test_ldapauthenticator.py
+++ b/ldapauthenticator/tests/test_ldapauthenticator.py
@@ -92,8 +92,8 @@ async def test_ldap_auth_search_filter(authenticator):
     assert authorized is None
 
 
-async def test_ldap_auth_user_info_attributes(authenticator):
-    authenticator.user_info_attributes = ["employeeType"]
+async def test_ldap_auth_state_attributes(authenticator):
+    authenticator.auth_state_attributes = ["employeeType"]
     # proper username and password in allowed group
     authorized = await authenticator.get_authenticated_user(
         None, {"username": "fry", "password": "fry"}

--- a/ldapauthenticator/tests/test_ldapauthenticator.py
+++ b/ldapauthenticator/tests/test_ldapauthenticator.py
@@ -90,3 +90,13 @@ async def test_ldap_auth_search_filter(authenticator):
         None, {"username": "zoidberg", "password": "zoidberg"}
     )
     assert authorized is None
+
+
+async def test_ldap_auth_user_info_attributes(authenticator):
+    authenticator.user_info_attributes = ['employeeType']
+    # proper username and password in allowed group
+    authorized = await authenticator.get_authenticated_user(
+        None, {"username": "fry", "password": "fry"}
+    )
+    assert authorized["name"] == "fry"
+    assert authorized["auth_state"] == {'employeeType': ['Delivery boy']}


### PR DESCRIPTION
Adds a new property `user_info_attributes` that lists additional LDAP fields to lookup and return in `auth_state` for a valid user.

Example use: Run a containerised singleuser server as the numeric user ID from LDAP so that files created on a shared external mount have the expected owner ID.