### PR TITLE
Ignore username returned by resolve_username

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,12 @@ If set to True, escape special chars in userdn when authenticating in LDAP.
 On some LDAP servers, when userdn contains chars like '(', ')', '\' authentication may fail when those chars
 are not escaped.
 
+#### `LDAPAuthenticator.use_lookup_dn_username` ####
+
+If set to True (the default) the username used to build the DN string is returned as the username when `lookup_dn` is True.
+
+When authenticating on a Linux machine against an AD server this might return something different from the supplied UNIX username. In this case setting this option to False might be a solution.
+
 ## Compatibility ##
 
 This has been tested against an OpenLDAP server, with the client

--- a/ldapauthenticator/ldapauthenticator.py
+++ b/ldapauthenticator/ldapauthenticator.py
@@ -214,6 +214,16 @@ class LDAPAuthenticator(Authenticator):
         help="List of attributes to be searched"
     )
 
+    use_lookup_dn_username = Bool(
+        True,
+        config=True,
+        help="""
+        If set to true uses the `lookup_dn_user_dn_attribute` attribute as username instead of the supplied one.
+
+        This can be useful in an heterogeneous environment, when supplying a UNIX username to authenticate against AD.
+        """
+    )
+
     def resolve_username(self, username_supplied_by_user):
         search_dn = self.lookup_dn_search_user
         if self.escape_userdn:
@@ -410,7 +420,10 @@ class LDAPAuthenticator(Authenticator):
                 self.log.warn(msg.format(username=username))
                 return None
 
-        return username
+        if self.use_lookup_dn_username:
+            return username
+        else:
+            return data['username']
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds a new configuration option `use_lookup_dn_username`, defaulting to True, that if False lets one ignore the username generated from `resolve_username`. 

This is helpful in mixed Linux/AD environments, where whatever `resolve_username` returns might be needed to build the DN for authentication, but where the initially supplied username might be what is actually supposed to be used on the machine running the hub.