### PR TITLE
Allow authentication with empty bind_dn_template when using lookup_dn

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,17 @@ without a port name or protocol prefix.
 
 #### `LDAPAuthenticator.lookup_dn` or `LDAPAuthenticator.bind_dn_template` ####
 
-`bind_dn_template` is a template used to generate the full DN for a user from
-the human readable username.
+To authenticate a user we need the corresponding DN to bind against the LDAP server. The DN can be acquired by either:
 
-If `bind_dn_template` isn't explicitly configured and `lookup_dn=True`, a
-dynamically acquired value from a username lookup will be used instead.
+1. setting `bind_dn_template`, which is a list of string template used to
+   generate the full DN for a user from the human readable username, or
+2. setting `lookup_dn` to `True`, which does a reverse lookup to obtain the
+   user's DN. This is because ome LDAP servers, such as Active Directory, don't
+   always bind with the true DN.
 
-If `lookup_dn=False`, then `bind_dn_template` is required to be a non-empty
+##### `lookup_dn = False` #####
+
+If `lookup_dn = False`, then `bind_dn_template` is required to be a non-empty
 list of templates the users belong to. For example, if some of the users in your
 LDAP database have DN of the form `uid=Yuvipanda,ou=people,dc=wikimedia,dc=org`
 and some other users have DN like `uid=Mike,ou=developers,dc=wikimedia,dc=org`
@@ -83,10 +87,25 @@ uses [traitlets](https://traitlets.readthedocs.io) for configuration, and the
 
 The `{username}` is expanded into the username the user provides.
 
-If you are using the `lookup_dn = True` configuration option, the `{username}` is
-expanded to the full path to the LDAP object returned by the LDAP lookup. For example,
-on an Active Directory system `{username}` might expand to something like
-`CN=First M. Last,OU=An Example Organizational Unit,DC=EXAMPLE,DC=COM`.
+##### `lookup_dn = True` #####
+
+```python
+c.LDAPAuthenticator.lookup_dn = True
+```
+
+If `bind_dn_template` isn't explicitly configured, i.e. the empty list, the
+dynamically acquired value for DN from the username lookup will be used
+instead. If `bind_dn_template` is configured it will be used just like in the
+`lookup_dn = False` case.
+
+The `{username}` is expanded to the full path to the LDAP object returned by the
+LDAP lookup. For example, on an Active Directory system `{username}` might
+expand to something like `CN=First M. Last,OU=An Example Organizational
+Unit,DC=EXAMPLE,DC=COM`.
+
+Also, when using `lookup_dn = True` the options `user_search_base`,
+`user_attribute`, `lookup_dn_user_dn_attribute` and `lookup_dn_search_filter`
+are required, although their defaults might be sufficient for your use case.
 
 ### Optional configuration ###
 
@@ -127,16 +146,6 @@ Set this to be `True` to start SSL connection.
 
 Port to use to contact the LDAP server. Defaults to 389 if no SSL
 is being used, and 636 is SSL is being used.
-
-#### `LDAPAuthenticator.lookup_dn` ####
-
-Whether to try a reverse lookup to obtain the user's DN.  Some LDAP servers,
-such as Active Directory, don't always bind with the true DN, so this allows
-us to discover it based on the username.
-
-```python
-c.LDAPAuthenticator.lookup_dn = True
-```
 
 #### `LDAPAuthenticator.user_search_base` ####
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ uses [traitlets](https://traitlets.readthedocs.io) for configuration, and the
 
 The `{username}` is expanded into the username the user provides.
 
+If `lookup_dn` is True this setting may be empty and the DN from resolving the username will be used
 
 ### Optional configuration ###
 

--- a/README.md
+++ b/README.md
@@ -60,15 +60,15 @@ without a port name or protocol prefix.
 Template used to generate the full dn for a user from the human readable
 username.
 
-If this is left unconfigured with `lookup_dn = True`, a dynamically provided
-default value from looking up the username will be provided. If
-`lookup_dn = False`, `bind_dn_template` needs to be a non-empty list of templates
-the users belong to.
+If `bind_dn_template` isn't explicitly configured and `lookup_dn = True`, a
+dynamically acquired value from the username lookup will be used instead.
 
-For example, if some of the users in your LDAP database have DN
-of the form `uid=Yuvipanda,ou=people,dc=wikimedia,dc=org` and some other users
-have DN like `uid=Mike,ou=developers,dc=wikimedia,dc=org` where Yuvipanda and
-Mike are the usernames, you would set this config item to be:
+If `lookup_dn = False`, then `bind_dn_template` is required to be a non-empty
+list of templates the users belong to. For example, if some of the users in your
+LDAP database have DN of the form `uid=Yuvipanda,ou=people,dc=wikimedia,dc=org`
+and some other users have DN like `uid=Mike,ou=developers,dc=wikimedia,dc=org`
+where Yuvipanda and Mike are the usernames, you would set this config item to
+be:
 
 ```python
 c.LDAPAuthenticator.bind_dn_template = [

--- a/README.md
+++ b/README.md
@@ -55,20 +55,20 @@ Address of the LDAP Server to contact. Just use a bare hostname or IP,
 without a port name or protocol prefix.
 
 
-#### `LDAPAuthenticator.bind_dn_template` ####
+#### `LDAPAuthenticator.lookup_dn` or `LDAPAuthenticator.bind_dn_template` ####
 
-Template used to generate the full dn for a user from the human readable
-username.
+`bind_dn_template` is a template used to generate the full DN for a user from
+the human readable username.
 
-If `bind_dn_template` isn't explicitly configured and `lookup_dn = True`, a
-dynamically acquired value from the username lookup will be used instead.
+If `bind_dn_template` isn't explicitly configured and `lookup_dn=True`, a
+dynamically acquired value from a username lookup will be used instead.
 
-If `lookup_dn = False`, then `bind_dn_template` is required to be a non-empty
+If `lookup_dn=False`, then `bind_dn_template` is required to be a non-empty
 list of templates the users belong to. For example, if some of the users in your
 LDAP database have DN of the form `uid=Yuvipanda,ou=people,dc=wikimedia,dc=org`
 and some other users have DN like `uid=Mike,ou=developers,dc=wikimedia,dc=org`
-where Yuvipanda and Mike are the usernames, you would set this config item to
-be:
+where `Yuvipanda` and `Mike` are the usernames, you would set this config item
+to be:
 
 ```python
 c.LDAPAuthenticator.bind_dn_template = [

--- a/ldapauthenticator/ldapauthenticator.py
+++ b/ldapauthenticator/ldapauthenticator.py
@@ -343,22 +343,20 @@ class LDAPAuthenticator(Authenticator):
             self.log.warning("username:%s Login denied for blank password", username)
             return None
 
+        bind_dn_template = self.bind_dn_template
+        if isinstance(bind_dn_template, str):
+            # bind_dn_template should be of type List[str]
+            bind_dn_template = [bind_dn_template]
+
         if self.lookup_dn:
             username, resolved_dn = self.resolve_username(username)
             if not username:
                 return None
-
-        if self.lookup_dn:
             if str(self.lookup_dn_user_dn_attribute).upper() == "CN":
                 # Only escape commas if the lookup attribute is CN
                 username = re.subn(r"([^\\]),", r"\1\,", username)[0]
-
-        bind_dn_template = self.bind_dn_template
-        if not bind_dn_template and self.lookup_dn:
-            bind_dn_template = [resolved_dn]
-        if isinstance(bind_dn_template, str):
-            # bind_dn_template should be of type List[str]
-            bind_dn_template = [bind_dn_template]
+            if not bind_dn_template:
+                bind_dn_template = [resolved_dn]
 
         is_bound = False
         for dn in bind_dn_template:

--- a/ldapauthenticator/ldapauthenticator.py
+++ b/ldapauthenticator/ldapauthenticator.py
@@ -279,7 +279,7 @@ class LDAPAuthenticator(Authenticator):
             )
             return (None, None)
 
-        user_dn = response[0]['attributes'][self.lookup_dn_user_dn_attribute]
+        user_dn = response[0]["attributes"][self.lookup_dn_user_dn_attribute]
         if isinstance(user_dn, list):
             if len(user_dn) == 0:
                 return (None, None)
@@ -292,12 +292,14 @@ class LDAPAuthenticator(Authenticator):
                     "first among these ('{first_entry}') was used. The other "
                     "entries ({other_entries}) were ignored."
                 )
-                self.log.warn(msg.format(
-                    username=username_supplied_by_user,
-                    attribute=self.lookup_dn_user_dn_attribute,
-                    first_entry=user_dn[0],
-                    other_entries=", ".join(user_dn[1:]),
-                ))
+                self.log.warn(
+                    msg.format(
+                        username=username_supplied_by_user,
+                        attribute=self.lookup_dn_user_dn_attribute,
+                        first_entry=user_dn[0],
+                        other_entries=", ".join(user_dn[1:]),
+                    )
+                )
                 user_dn = user_dn[0]
 
         return (user_dn, response[0]["dn"])

--- a/ldapauthenticator/ldapauthenticator.py
+++ b/ldapauthenticator/ldapauthenticator.py
@@ -345,10 +345,17 @@ class LDAPAuthenticator(Authenticator):
             self.log.warning("username:%s Login denied for blank password", username)
             return None
 
+        # bind_dn_template should be of type List[str]
         bind_dn_template = self.bind_dn_template
         if isinstance(bind_dn_template, str):
-            # bind_dn_template should be of type List[str]
             bind_dn_template = [bind_dn_template]
+
+        # sanity check
+        if not self.lookup_dn and not bind_dn_template:
+            self.log.warning(
+                "Login not allowed, please configure 'lookup_dn' or 'bind_dn_template'."
+            )
+            return None
 
         if self.lookup_dn:
             username, resolved_dn = self.resolve_username(username)


### PR DESCRIPTION
This PR changes `resolve_username` to also return the DN it resolved and to reuse it for authentication.

This is helpful when one doesn't control the LDAP server against which one authenticates and anything below `search_base` would be ok, but one doesn't want to list all possibilities in `bind_dn_template`. As an added bonus, the authentication does not have to loop over (possibly) all templates.

### Updated by @consideRatio
Closes #131
Closes #88