### PR TITLE
Avoid binding the connection twice

### DIFF
--- a/ldapauthenticator/ldapauthenticator.py
+++ b/ldapauthenticator/ldapauthenticator.py
@@ -343,7 +343,7 @@ class LDAPAuthenticator(Authenticator):
                     exc_msg=exc.args[0] if exc.args else "",
                 )
             else:
-                is_bound = conn.bind()
+                is_bound = True if conn.bound else conn.bind()
             msg = msg.format(username=username, userdn=userdn, is_bound=is_bound)
             self.log.debug(msg)
             if is_bound:


### PR DESCRIPTION
In my current environment the authentication is secured with a password + OTP. When the connection is auto binding and well call `bind()` again the token is re-used, therefore invalid and the connection closes.

With this change the `bind()` is only called, when the connection isn't bound already.