### PR TITLE
Add bind_dn_template to Active Directory instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ c.LDAPAuthenticator.user_search_base = 'ou=people,dc=wikimedia,dc=org'
 c.LDAPAuthenticator.user_attribute = 'sAMAccountName'
 c.LDAPAuthenticator.lookup_dn_user_dn_attribute = 'cn'
 c.LDAPAuthenticator.escape_userdn = False
+c.LDAPAuthenticator.bind_dn_template = '{username}'
 ```
 
 In setup above, first LDAP will be searched (with account ldap_search_user_technical_account) for users that have sAMAccountName=login

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ without a port name or protocol prefix.
 #### `LDAPAuthenticator.bind_dn_template` ####
 
 Template used to generate the full dn for a user from the human readable
-username. This must be set to either empty `[]` or to a list of templates the
+username. This must be set to a non-empty list of templates the
 users belong to. For example, if some of the users in your LDAP database have DN
 of the form `uid=Yuvipanda,ou=people,dc=wikimedia,dc=org` and some other users
 have DN like `uid=Mike,ou=developers,dc=wikimedia,dc=org` where Yuvipanda and
@@ -72,6 +72,14 @@ uses [traitlets](https://traitlets.readthedocs.io) for configuration, and the
 
 The `{username}` is expanded into the username the user provides.
 
+If you are using the `lookup_dn = True` configuration option, the `{username}` is
+expanded to the full path to the LDAP object returned by the LDAP lookup. For example,
+on an Active Directory system `{username}` might expand to something like
+`CN=First M. Last,OU=An Example Organizational Unit,DC=EXAMPLE,DC=COM`.
+
+You must configure this setting explicitly. If you leave this setting
+configured with the default value (`[]`), the LDAP bind/lookup **will not** be
+performed and authentication will fail.
 
 ### Optional configuration ###
 

--- a/ldapauthenticator/ldapauthenticator.py
+++ b/ldapauthenticator/ldapauthenticator.py
@@ -137,6 +137,7 @@ class LDAPAuthenticator(Authenticator):
         c.LDAPAuthenticator.user_search_base = 'ou=people,dc=wikimedia,dc=org'
         c.LDAPAuthenticator.user_attribute = 'sAMAccountName'
         c.LDAPAuthenticator.lookup_dn_user_dn_attribute = 'cn'
+        c.LDAPAuthenticator.bind_dn_template = '{username}'
         ```
         """,
     )


### PR DESCRIPTION
The Active Directory authentication code path uses two accounts:
1) Read-only technical account to perform username -> userdn lookup
2) userdn + password to bind (to check the password is valid)

This code path is associated with the `lookup_dn=True` configuration
setting. When you have this setting in effect, you must also set
`bind_dn_template='{username}'`, otherwise the loop is not entered and
the code does not even attempt to bind at all. The code doesn't attempt
to perform "Step 2" and check if the password is valid.

Change the documentation to show the required configuration for
`bind_dn_template` when `lookup_dn=True` is in effect.