### PR TITLE
Travis deploy tags to PyPI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 dist: xenial
 language: python
-sudo: false
 cache:
   - pip
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ language: python
 sudo: false
 cache:
   - pip
-python:
-  - 3.7
-  - 3.6
 env:
   global:
     - ASYNC_TEST_TIMEOUT=15
@@ -52,8 +49,28 @@ after_failure:
       echo "or after-the-fact on already committed files with"
       echo "    pre-commit run --all-files"
     fi
-matrix:
+
+jobs:
+  allow_failures:
+    - python: nightly
   fast_finish: true
   include:
+    # Default stage: test
     - python: 3.6
       env: TEST=lint
+    - python: 3.7
+    - python: 3.6
+    - python: nightly
+    # Only deploy if all test jobs passed
+    - stage: deploy
+      python: 3.7
+      if: tag IS present
+      deploy:
+        provider: pypi
+        user: __token__
+        # password: see secret PYPI_PASSWORD variable
+        distributions: sdist bdist_wheel
+        on:
+          # Without this we get the note about:
+          # Skipping a deployment with the pypi provider because this branch is not permitted: <tag>
+          tags: true

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,74 @@
+# How to make a release
+
+`oauthenticator` is a package [available on
+PyPI](https://pypi.org/project/oauthenticator/) and
+[conda-forge](https://conda-forge.org/). These are instructions on how to make a
+release on PyPI. The PyPI release is done automatically by TravisCI when a tag
+is pushed.
+
+For you to follow along according to these instructions, you need:
+- To have push rights to the [oauthenticator GitHub
+  repository](https://github.com/jupyterhub/oauthenticator).
+
+## Steps to make a release
+
+1. Checkout master and make sure it is up to date.
+
+   ```shell
+   ORIGIN=${ORIGIN:-origin} # set to the canonical remote, e.g. 'upstream' if 'origin' is not the official repo
+   git checkout master
+   git fetch $ORIGIN master
+   git reset --hard $ORIGIN/master
+   # WARNING! This next command deletes any untracked files in the repo
+   git clean -xfd
+   ```
+
+1. Update [CHANGELOG.md](CHANGELOG.md). Doing this can be made easier with the
+   help of the
+   [choldgraf/github-activity](https://github.com/choldgraf/github-activity)
+   utility.
+
+1. Set the `version_info` variable in [_version.py](oauthenticator/_version.py)
+   appropriately and make a commit.
+
+   ```
+   git add oauthenticator/_version.py
+   VERSION=...  # e.g. 1.2.3
+   git commit -m "release $VERSION"
+   ```
+
+1. Reset the `version_info` variable in
+   [_version.py](oauthenticator/_version.py) appropriately with an incremented
+   patch version and a `dev` element, then make a commit.
+   ```
+   git add oauthenticator/_version.py
+   git commit -m "back to dev"
+   ```
+
+1. Push your two commits to master.
+
+   ```shell
+   # first push commits without a tags to ensure the
+   # commits comes through, because a tag can otherwise
+   # be pushed all alone without company of rejected
+   # commits, and we want have our tagged release coupled
+   # with a specific commit in master
+   git push $ORIGIN master
+   ```
+
+1. Create a git tag for the pushed release commit and push it.
+
+   ```shell
+   git tag -a $VERSION -m $VERSION HEAD~1
+
+   # then verify you tagged the right commit
+   git log
+
+   # then push it
+   git push $ORIGIN refs/tags/$VERSION
+   ```
+
+1. Following the release to PyPI, an automated PR should arrive to
+   [conda-forge/oauthenticator-feedstock](https://github.com/conda-forge/oauthenticator-feedstock),
+   check for the tests to succeed on this PR and then merge it to successfully
+   update the package for `conda` on the conda-forge channel.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,14 +1,13 @@
 # How to make a release
 
-`oauthenticator` is a package [available on
-PyPI](https://pypi.org/project/oauthenticator/) and
-[conda-forge](https://conda-forge.org/). These are instructions on how to make a
-release on PyPI. The PyPI release is done automatically by TravisCI when a tag
-is pushed.
+`ldapauthenticator` is a package [available on PyPI](https://pypi.org/project/jupyterhub-ldapauthenticator/) and
+[conda-forge](https://anaconda.org/conda-forge/jupyterhub-ldapauthenticator).
+These are instructions on how to make a release on PyPI.
+The PyPI release is done automatically by TravisCI when a tag is pushed.
 
 For you to follow along according to these instructions, you need:
-- To have push rights to the [oauthenticator GitHub
-  repository](https://github.com/jupyterhub/oauthenticator).
+- To have push rights to the [ldapauthenticator GitHub
+  repository](https://github.com/jupyterhub/ldapauthenticator).
 
 ## Steps to make a release
 
@@ -23,25 +22,20 @@ For you to follow along according to these instructions, you need:
    git clean -xfd
    ```
 
-1. Update [CHANGELOG.md](CHANGELOG.md). Doing this can be made easier with the
-   help of the
-   [choldgraf/github-activity](https://github.com/choldgraf/github-activity)
-   utility.
-
-1. Set the `version_info` variable in [_version.py](oauthenticator/_version.py)
+1. Set the `version` variable in [setup.py](setup.py)
    appropriately and make a commit.
 
    ```
-   git add oauthenticator/_version.py
+   git add setup.py
    VERSION=...  # e.g. 1.2.3
    git commit -m "release $VERSION"
    ```
 
-1. Reset the `version_info` variable in
-   [_version.py](oauthenticator/_version.py) appropriately with an incremented
+1. Reset the `version` variable in
+   [setup.py](setup.py) appropriately with an incremented
    patch version and a `dev` element, then make a commit.
    ```
-   git add oauthenticator/_version.py
+   git add setup.py
    git commit -m "back to dev"
    ```
 
@@ -69,6 +63,6 @@ For you to follow along according to these instructions, you need:
    ```
 
 1. Following the release to PyPI, an automated PR should arrive to
-   [conda-forge/oauthenticator-feedstock](https://github.com/conda-forge/oauthenticator-feedstock),
+   [conda-forge/ldapauthenticator-feedstock](https://github.com/conda-forge/jupyterhub-ldapauthenticator-feedstock),
    check for the tests to succeed on this PR and then merge it to successfully
    update the package for `conda` on the conda-forge channel.


### PR DESCRIPTION
This more or less copies the Travis PyPI deployment steps from https://github.com/jupyterhub/oauthenticator/blob/e9c6404e723a7cc0b118f055a42ba462fafe04a9/.travis.yml and the RELEASE.md writtren by @consideRatio in https://github.com/jupyterhub/oauthenticator/blob/3d7840da11a5e0b4af9e38e3045eb10b6e2bc2a7/RELEASE.md which should mean this repo will be automatically pushed to PyPI whenever a release is tagged.

See https://github.com/jupyterhub/ldapauthenticator/issues/150

Final step @consideRatio is for a PyPI maintainer to create the `PYPI_PASSWORD` secret Travis variable