### PR TITLE
Add long description for pypi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,8 @@ setup(
     name="jupyterhub-ldapauthenticator",
     version=version,
     description="LDAP Authenticator for JupyterHub",
+    long_description=open("README.md").read(),
+    long_description_content_type="text/markdown",
     url="https://github.com/jupyterhub/ldapauthenticator",
     author="Yuvi Panda",
     author_email="yuvipanda@riseup.net",


### PR DESCRIPTION
This should make README.md appear on the pypi home page with the next full release https://pypi.org/project/jupyterhub-ldapauthenticator/. Currently it says

> The author of this package has not provided a project description