### PR TITLE
Allow users to configure group search filter and attributes (`group_search_filter` and `group_attributes` config)

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,35 @@ c.LDAPAuthenticator.allowed_groups = [
 ]
 ```
 
+#### `LDAPAuthenticator.group_search_filter`
+
+The LDAP group search filter.
+
+The default value is an LDAP OR search that looks like the following:
+
+```
+(|(member={userdn})(uniqueMember={userdn})(memberUid={uid}))
+```
+
+So it basically compares the `userdn` attribute against the `member` attribute,
+then against the `uniqueMember`, and finally checks the `memberUid` against
+the `uid`.
+
+If you modify this value, you probably want to change `group_attributes` too.
+Here is an example that should work with OpenLDAP servers.
+
+```
+(member={userdn})
+```
+
+#### `LDAPAuthenticator.group_attributes`
+
+A list of attributes used when searching for LDAP groups.
+
+By default, it uses `member`, `uniqueMember`, and `memberUid`. Certain
+servers may reject invalid values causing exceptions during
+authentication.
+
 #### `LDAPAuthenticator.valid_username_regex`
 
 All usernames will be checked against this before being sent

--- a/ldapauthenticator/tests/conftest.py
+++ b/ldapauthenticator/tests/conftest.py
@@ -17,6 +17,10 @@ def authenticator():
     authenticator.escape_userdn = True
     authenticator.attributes = ["uid", "cn", "mail", "ou"]
     authenticator.use_lookup_dn_username = False
+    authenticator.group_filter = (
+        "(|(member={userdn})(uniqueMember={userdn})(memberUid={uid}))"
+    )
+    authenticator.group_attributes = ["member", "uniqueMember", "memberUid"]
 
     authenticator.allowed_groups = [
         "cn=admin_staff,ou=people,dc=planetexpress,dc=com",

--- a/ldapauthenticator/tests/conftest.py
+++ b/ldapauthenticator/tests/conftest.py
@@ -17,10 +17,6 @@ def authenticator():
     authenticator.escape_userdn = True
     authenticator.attributes = ["uid", "cn", "mail", "ou"]
     authenticator.use_lookup_dn_username = False
-    authenticator.group_filter = (
-        "(|(member={userdn})(uniqueMember={userdn})(memberUid={uid}))"
-    )
-    authenticator.group_attributes = ["member", "uniqueMember", "memberUid"]
 
     authenticator.allowed_groups = [
         "cn=admin_staff,ou=people,dc=planetexpress,dc=com",

--- a/ldapauthenticator/tests/test_ldapauthenticator.py
+++ b/ldapauthenticator/tests/test_ldapauthenticator.py
@@ -104,3 +104,15 @@ async def test_ldap_auth_state_attributes(authenticator):
     )
     assert authorized["name"] == "fry"
     assert authorized["auth_state"] == {"employeeType": ["Delivery boy"]}
+
+
+async def test_ldap_auth_state_attributes2(authenticator):
+    authenticator.group_search_filter = "(cn=ship_crew)"
+    authenticator.group_attributes = ["cn"]
+    authenticator.auth_state_attributes = ["description"]
+    # proper username and password in allowed group
+    authorized = await authenticator.get_authenticated_user(
+        None, {"username": "leela", "password": "leela"}
+    )
+    assert authorized["name"] == "leela"
+    assert authorized["auth_state"] == {"description": ["Mutant"]}


### PR DESCRIPTION
This change allowed me to connect to another server that was rejecting the connection due to only `member` being in its schema. Other attributes caused it to raise an exception, failing the authentication.

Closes #62
Closes #133 
Related to #145 