### PR TITLE
Fix traitlets warnings when running tests

### DIFF
--- a/ldapauthenticator/ldapauthenticator.py
+++ b/ldapauthenticator/ldapauthenticator.py
@@ -72,7 +72,7 @@ class LDAPAuthenticator(Authenticator):
     allowed_groups = List(
         config=True,
         allow_none=True,
-        default=None,
+        default_value=None,
         help="""
         List of LDAP group DNs that users could be members of to be granted access.
 
@@ -118,7 +118,7 @@ class LDAPAuthenticator(Authenticator):
 
     user_search_base = Unicode(
         config=True,
-        default=None,
+        default_value=None,
         allow_none=True,
         help="""
         Base for looking up user accounts in the directory, if `lookup_dn` is set to True.
@@ -144,7 +144,7 @@ class LDAPAuthenticator(Authenticator):
 
     user_attribute = Unicode(
         config=True,
-        default=None,
+        default_value=None,
         allow_none=True,
         help="""
         Attribute containing user's name, if `lookup_dn` is set to True.


### PR DESCRIPTION
Running tests locally got warnings such as

```
(venv) kinow@ranma:~/Development/python/workspace/ldapauthenticator$ pytest
============================================================================= test session starts =============================================================================
platform linux -- Python 3.8.3, pytest-5.4.3, py-1.9.0, pluggy-0.13.1
rootdir: /home/kinow/Development/python/workspace/ldapauthenticator, inifile: pytest.ini
plugins: asyncio-0.14.0, requests-mock-1.8.0, cov-2.10.0
collected 7 items                                                                                                                                                             

ldapauthenticator/tests/test_ldapauthenticator.py .......                                                                                                               [100%]

============================================================================== warnings summary ===============================================================================
ldapauthenticator/ldapauthenticator.py:72
  /home/kinow/Development/python/workspace/ldapauthenticator/ldapauthenticator/ldapauthenticator.py:72: DeprecationWarning: metadata {'default': None} was set from the constructor. With traitlets 4.1, metadata should be set using the .tag() method, e.g., Int().tag(key1='value1', key2='value2')
    allowed_groups = List(

-- Docs: https://docs.pytest.org/en/latest/warnings.html
======================================================================== 7 passed, 1 warning in 1.27s =========================================================================
```

Fixed using the `.tag`. Tests passing locally, no more warnings

```
(venv) kinow@ranma:~/Development/python/workspace/ldapauthenticator$ pytest
============================================================================= test session starts =============================================================================
platform linux -- Python 3.8.3, pytest-5.4.3, py-1.9.0, pluggy-0.13.1
rootdir: /home/kinow/Development/python/workspace/ldapauthenticator, inifile: pytest.ini
plugins: asyncio-0.14.0, requests-mock-1.8.0, cov-2.10.0
collected 7 items                                                                                                                                                             

ldapauthenticator/tests/test_ldapauthenticator.py .......                                                                                                               [100%]

============================================================================== 7 passed in 1.26s ==============================================================================
```