### PR TITLE
Fix testing ldap server port mapping for broken gate

### DIFF
--- a/ci/docker-ldap.sh
+++ b/ci/docker-ldap.sh
@@ -6,7 +6,7 @@ set -e
 
 NAME="hub-test-ldap"
 DOCKER_RUN="docker run -d --name $NAME"
-RUN_ARGS="-p 389:389 -p 636:636 rroemhild/test-openldap"
+RUN_ARGS="-p 389:10389 -p 636:10636 rroemhild/test-openldap"
 
 docker rm -f "$NAME" 2>/dev/null || true
 


### PR DESCRIPTION
Current CI gate has been broken because testing container image (rroemhild/test-openldap) changed the service
ports from 389/636 to 10389/10636. (*1) That causes all existing test cases failed down as LDAP communication errors.

This pull request changes the service port according to the change, then that passed the CI successfully.

Closes https://github.com/jupyterhub/ldapauthenticator/issues/191

*1: https://github.com/rroemhild/docker-test-openldap/commit/adb4650727e0123c7c24c7d7ce8609d12384a29b
