### PR TITLE
Add study participation notice to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,20 @@
 
 Simple LDAP Authenticator Plugin for JupyterHub
 
+---
+
+Please note that this repository is participating in a study into sustainability
+of open source projects. Data will be gathered about this repository for
+approximately the next 12 months, starting from 2021-06-11.
+
+Data collected will include number of contributors, number of PRs, time taken to
+close/merge these PRs, and issues closed.
+
+For more information, please visit
+[our informational page](https://sustainable-open-science-and-software.github.io/) or download our [participant information sheet](https://sustainable-open-science-and-software.github.io/assets/PIS_sustainable_software.pdf).
+
+---
+
 ## Installation ##
 
 You can install it from pip with:

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Data collected will include number of contributors, number of PRs, time taken to
 close/merge these PRs, and issues closed.
 
 For more information, please visit
-[our informational page](https://sustainable-open-science-and-software.github.io/) or download our [participant information sheet](https://sustainable-open-science-and-software.github.io/assets/PIS_sustainable_software.pdf).
+[the informational page](https://sustainable-open-science-and-software.github.io/) or download the [participant information sheet](https://sustainable-open-science-and-software.github.io/assets/PIS_sustainable_software.pdf).
 
 ---
 


### PR DESCRIPTION
This PR add a notice to the readme informing users that the repo is participating in a open source sustainability study, see https://github.com/jupyterhub/team-compass/issues/417 for details