### PR TITLE
add option to check `allowed_groups` with the configured ldap search user

### DIFF
--- a/ldapauthenticator/tests/test_ldapconnection_usage.py
+++ b/ldapauthenticator/tests/test_ldapconnection_usage.py
@@ -1,0 +1,126 @@
+"""Tests the usage of both ldap connections of the ldap authenticator.
+"""
+import os
+from unittest.mock import MagicMock, call, ANY
+import pytest
+
+from ..ldapauthenticator import LDAPAuthenticator
+
+
+@pytest.fixture
+def authenticator_setup():
+    """Provides a configured and mocked authenticator as well as a mocked search and user connection.
+
+    Note: don't be confused with the connection settings here, they just serve as valid configuration and are not used.
+    """
+    # configure authenticator
+    authenticator = LDAPAuthenticator()
+    authenticator.server_address = "localhost"
+    authenticator.lookup_dn = False
+    authenticator.bind_dn_template = "cn={username},ou=people,dc=planetexpress,dc=com"
+    authenticator.user_search_base = "ou=people,dc=planetexpress,dc=com"
+    authenticator.user_attribute = "uid"
+    authenticator.lookup_dn_user_dn_attribute = "cn"
+    authenticator.escape_userdn = True
+    authenticator.attributes = ["uid", "cn", "mail", "ou"]
+    authenticator.use_lookup_dn_username = False
+    # leela is being authenticated, she's member of that group
+    authenticator.allowed_groups = [
+        "cn=ship_crew,ou=people,dc=planetexpress,dc=com",
+    ]
+    # search user is 'hermes'
+    authenticator.lookup_dn_search_user = 'hermes'
+    authenticator.lookup_dn_search_password = 'hermes'
+
+    # mock ldap connections: return either the one for the search user or for the user to be authenticated
+    connection_search_mock = MagicMock()
+    connection_user_mock = MagicMock()
+    def connection_mock(*args, **kwargs):
+        if 'userdn' in kwargs and kwargs['userdn'] == 'hermes':
+            return connection_search_mock
+        else:
+            return connection_user_mock
+    authenticator.get_connection = MagicMock( side_effect = connection_mock )
+
+    # 1) search: bind method should return True
+    connection_search_mock.bind = MagicMock( return_value = True )
+
+    # 2) search: lookup dn of user to be authenticated » deactivated
+
+    # 3) user: bound should be False so that bind method is called returning True
+    connection_user_mock.bound = False
+    connection_user_mock.bind = MagicMock( return_value = True)
+
+    # 4) user: search filter are empty » deactivated
+
+    # 5) search or user: allowed groups » configured in test methods
+
+    # 6) user: get_user_attributes(connection, userdn) » returns dict with entry attributes
+    authenticator.get_user_attributes = MagicMock( return_value = { 'uid': 'leela', 'cn': 'Turanga Leela' } )
+
+    return authenticator, connection_search_mock, connection_user_mock
+
+
+async def test_allowed_groups_check_with_user_connection(authenticator_setup):
+    """Checks the method calls on both ldap connections when the `allowed_groups` are check with the
+    connection of the user being authenticated (default).
+    """
+    # unpack + assert object setup
+    authenticator, connection_search_mock, connection_user_mock = authenticator_setup
+    assert authenticator is not None and connection_search_mock is not None and connection_user_mock is not None
+    assert authenticator.lookup_dn is False
+    assert not authenticator.search_filter
+
+    # assert default value
+    assert authenticator.use_search_user_to_check_groups is False
+
+    # 5) user: allowed groups » simply return True for the one group
+    connection_user_mock.search = MagicMock( return_value = True )
+
+    # authenticate leela
+    result = await authenticator.authenticate( None, { 'username': 'leela', 'password': 'leela' } )
+    assert 'name' in result
+    assert result['name'] == 'leela'
+
+    # assert method calls on mocks
+    expected_search_mock_calls = [
+        call.bind(),
+    ]
+    assert connection_search_mock.mock_calls == expected_search_mock_calls
+    expected_user_mock_calls = [
+        call.bind(),
+        call.search('cn=ship_crew,ou=people,dc=planetexpress,dc=com', search_scope = ANY, search_filter = ANY, attributes = ANY)
+    ]
+    assert connection_user_mock.mock_calls == expected_user_mock_calls
+
+async def test_allowed_groups_check_with_search_connection(authenticator_setup):
+    """Checks the method calls on both ldap connections when the `allowed_groups` are check with the
+    connection of the configured search user.
+    """
+    # unpack + assert object setup
+    authenticator, connection_search_mock, connection_user_mock = authenticator_setup
+    assert authenticator is not None and connection_search_mock is not None and connection_user_mock is not None
+    assert authenticator.lookup_dn is False
+    assert not authenticator.search_filter
+
+    # enable allowed groups check using the search user connection
+    authenticator.use_search_user_to_check_groups = True
+
+    # 5) search: allowed groups » simply return True for the one group
+    connection_search_mock.search = MagicMock( return_value = True )
+
+    # authenticate leela
+    result = await authenticator.authenticate( None, { 'username': 'leela', 'password': 'leela' } )
+    assert 'name' in result
+    assert result['name'] == 'leela'
+
+    # assert method calls on mocks
+    expected_search_mock_calls = [
+        call.bind(),
+        call.search('cn=ship_crew,ou=people,dc=planetexpress,dc=com', search_scope = ANY, search_filter = ANY, attributes = ANY)
+    ]
+    assert connection_search_mock.mock_calls == expected_search_mock_calls
+    expected_user_mock_calls = [
+        call.bind(),
+    ]
+    assert connection_user_mock.mock_calls == expected_user_mock_calls


### PR DESCRIPTION
### Summary

This pull request adds the boolean option `use_search_user_to_check_groups` which allows to switch the ldap user that is used to verify the membership of the user being authenticated with the `allowed_groups`. Its default value is `False` so that the behavior of the ldap authenticator is not changed.

Thus, if `use_search_user_to_check_groups` is:
- `False`: the user being authenticated is used to check if she/he is member of one of the `allowed_groups` (current behavior)
- `True`: the configured search user is used to check if the user being authenticated is member of one of the `allowed_groups`

This PR adresses #183.

### Addressed Behavior

The plugin uses a so called *search user* to lookup the dn of the user to be authenticated. By doing so one connection is established to the ldap server. The authentication is done using an ldap bind which creates another connection to the server. Thus two connections to the ldap server are established with two different users: the search user and the user being authenticated.

#### Current Behavior

All subsequent ldap searches are performed with the connection of the authenticated user and not with the connection of the configured search user. Thus, the ldap query to check the `allowed_groups` is performed with the authenticated user instead of the search user.

#### Behavior with this PR

As the default value of the option `use_search_user_to_check_groups` is `False` the current behavior is not changed. If set to `True` the connection of the search user is used to check the `allowed_groups` for the user being authenticated.

### Background

Our organization follows a consequent security approach where ldap groups are used for authorization by member check. But there is no need that the groups are itself accessible by the members. The users just don't have the permission to look up the ldap groups. In such a setting only the configured ldap *search user* has such permissions.

### Outline of Changes

- add option `use_search_user_to_check_groups`
- add parameter `connection` to method signature of `resolve_username`
- moved the implementation to establish the connection with the search user from the method `resolve_username` into method `authenticate` to have the connection object with the search user available in method `authenticate`
- add some comments in `authenticate` to outline whats going on
- use either the object `connectIon_user` or `connection_search` to separate the connections of both users

Unfortunately I am not an ldap admin and couldn't provide an ldap server setup with such permissions set on an ldap test server. Instead to test the introduced ldap authenticator option I opted to mock the ldap connection objects and check if they are called appropriately.

I can confirm that it works with juypterhub 2.1.1.