### PR TITLE
Let the LDAPAuthenticator manage user.groups

### DIFF
--- a/ldapauthenticator/ldapauthenticator.py
+++ b/ldapauthenticator/ldapauthenticator.py
@@ -498,7 +498,7 @@ class LDAPAuthenticator(Authenticator):
                 groupname = response["attributes"]["cn"][0]
                 user_groups.append(groupname)
 
-            self.log.debug("Found user LDAP groups: " + user_groups)
+            self.log.debug("Found user LDAP groups: " + str(user_groups))
 
             return_data["groups"] = user_groups;
 


### PR DESCRIPTION
Hello everyone,

with this PR `user.groups` will be filled using `group_search_base` and `manage_groups`.
We currently use this to be able to load user specific configurations using the wrapspawner.

This is certainly helpful for others as well.

Best regards
mawigh