### PR TITLE
Add new featrue: refresh_user

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
   hooks:
   - id: reorder-python-imports
 - repo: https://github.com/ambv/black
-  rev: 19.10b0
+  rev: 22.3.0
   hooks:
   - id: black
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/README.md
+++ b/README.md
@@ -218,6 +218,11 @@ If set to True (the default) the username used to build the DN string is returne
 
 When authenticating on a Linux machine against an AD server this might return something different from the supplied UNIX username. In this case setting this option to False might be a solution.
 
+#### `LDAPAuthenticator.enable_refresh` ####
+If set to True it then periodically checks if a user is still in one the allowed groups.
+This requires `lookup_dn_search_user` and `lookup_dn_search_user` to be set if anonymous login is not allowed.
+The refresh interval can be set with `c.Authenticator.auth_refresh_age`.
+
 ## Compatibility ##
 
 This has been tested against an OpenLDAP server, with the client

--- a/ldapauthenticator/tests/test_ldapauthenticator.py
+++ b/ldapauthenticator/tests/test_ldapauthenticator.py
@@ -1,4 +1,5 @@
 # Inspired by https://github.com/jupyterhub/jupyterhub/blob/master/jupyterhub/tests/test_auth.py
+from unittest.mock import Mock
 
 
 async def test_ldap_auth_allowed(authenticator):
@@ -100,3 +101,45 @@ async def test_ldap_auth_state_attributes(authenticator):
     )
     assert authorized["name"] == "fry"
     assert authorized["auth_state"] == {"employeeType": ["Delivery boy"]}
+
+
+async def test_ldap_refresh_user(authenticator):
+    authenticator.allowed_groups = [
+        "cn=admin_staff,ou=people,dc=planetexpress,dc=com",
+        "cn=ship_crew,ou=people,dc=planetexpress,dc=com",
+    ]
+
+    authenticator.enable_refresh = True
+    mock = Mock()
+    attrs = {"name": "zoidberg"}
+    mock.configure_mock(**attrs)
+
+    is_valid = await authenticator.refresh_user(mock, None)
+    assert is_valid == False
+
+    attrs = {"name": "leela"}
+    mock.configure_mock(**attrs)
+
+    is_valid = await authenticator.refresh_user(mock, None)
+    assert is_valid == True
+
+
+async def test_ldap_refresh_user_disabled(authenticator):
+    authenticator.allowed_groups = [
+        "cn=admin_staff,ou=people,dc=planetexpress,dc=com",
+        "cn=ship_crew,ou=people,dc=planetexpress,dc=com",
+    ]
+
+    authenticator.enable_refresh = False
+    mock = Mock()
+    attrs = {"name": "zoidberg"}
+    mock.configure_mock(**attrs)
+
+    is_valid = await authenticator.refresh_user(mock, None)
+    assert is_valid == True
+
+    attrs = {"name": "leela"}
+    mock.configure_mock(**attrs)
+
+    is_valid = await authenticator.refresh_user(mock, None)
+    assert is_valid == True


### PR DESCRIPTION
Implements the method `refresh_user` of the superclass `Authenticator`.
It periodically checks if a user is still in one of the allowed groups. If a user is no longer a member of any of those groups, their session token is invalidated.

The feature can be enabled using the option `enable_refresh`, and only checks users if allowed groups are set.