### PR TITLE
Fix for escape_userdn

### DIFF
--- a/ldapauthenticator/ldapauthenticator.py
+++ b/ldapauthenticator/ldapauthenticator.py
@@ -298,6 +298,10 @@ class LDAPAuthenticator(Authenticator):
                 )
                 user_dn = user_dn[0]
 
+        # Escape username if escape_userdn is True
+        if self.escape_userdn:
+            user_dn = escape_filter_chars(user_dn)
+
         return (user_dn, response[0]["dn"])
 
     def get_connection(self, userdn, password):


### PR DESCRIPTION
Solution to https://github.com/jupyterhub/ldapauthenticator/issues/225

When escape_userdn = True the ldapauthenticator escapes special chars in userdn but does not escapes special chars in username. This does not cause an issue when allowed_groups is null but it does cause an issue when allowed_groups is not null. I suggest that the username is also escaped when escape_userdn = True or add another parameter dedicated to escape username