### PR TITLE
Update ldap testing server to the latest available version

### DIFF
--- a/ci/docker-ldap.sh
+++ b/ci/docker-ldap.sh
@@ -5,7 +5,7 @@ set -e
 # container based on the image rroemhild/test-openldap.
 #
 # ref: https://github.com/rroemhild/docker-test-openldap
-# ref: https://hub.docker.com/r/rroemhild/test-openldap/
+# ref: https://github.com/rroemhild/docker-test-openldap/pkgs/container/docker-test-openldap
 #
 # Stop any existing test-openldap container
 docker rm --force test-openldap 2>/dev/null || true
@@ -15,4 +15,11 @@ docker rm --force test-openldap 2>/dev/null || true
 # - 389:10389 (ldap)
 # - 636:10636 (ldaps)
 #
-docker run --detach --name=test-openldap -p 389:10389 -p 636:10636 rroemhild/test-openldap:2.1
+# Image updated 2024-09-12 to the latest commit's build
+# https://github.com/rroemhild/docker-test-openldap/commit/2645f2164ffb51ec4b5b4a9af0065ad7f2ffc1cf
+#
+IMAGE=ghcr.io/rroemhild/docker-test-openldap@sha256:107ecba713dd233f6f84047701d1b4dda03307d972814f2ae1db69b0d250544f
+docker run --detach --name=test-openldap -p 389:10389 -p 636:10636 $IMAGE
+
+# It takes a bit more than one second for the container to become ready
+sleep 3


### PR DESCRIPTION
The testing ldap server used is no longer available on dockerhub, but is on ghcr.