### PR TITLE
Fix escaping issue when escape_userdn and allowed_groups are configured

### DIFF
--- a/ldapauthenticator/ldapauthenticator.py
+++ b/ldapauthenticator/ldapauthenticator.py
@@ -450,12 +450,13 @@ class LDAPAuthenticator(Authenticator):
         is_bound = False
         for dn in bind_dn_template:
             userdn = dn.format(username=username)
-            if self.escape_userdn:
-                userdn = escape_filter_chars(userdn)
             self.log.debug(f"Attempting to bind {username} with {userdn}")
             msg = "Status of user bind {username} with {userdn} : {is_bound}"
             try:
-                conn = self.get_connection(userdn, password)
+                if self.escape_userdn:
+                    conn = self.get_connection(escape_filter_chars(userdn), password)
+                else:
+                    conn = self.get_connection(userdn, password)
             except ldap3.core.exceptions.LDAPBindError as exc:
                 is_bound = False
                 msg += "\n{exc_type}: {exc_msg}".format(


### PR DESCRIPTION
I think this a bug being fixed, but I'm not 100% sure. It is discussed in https://github.com/jupyterhub/ldapauthenticator/issues/243#issuecomment-2351140539. I think it should be an improvement though because it ensure we don't double-escape something.

I also think this enables:
- fixes #225
- closes #226 

Review help greatly appreciated @hammadab @Nikolai-Hlubek @m-erhardt, I've written this PR in the dark here without testing the change etc. Note that test failures for JupyterHub 5 are unrelated and to be resolved separately.