### PR TITLE
tests: avoid reuse of authenticator fixture between tests and add docstring

### DIFF
--- a/ldapauthenticator/tests/conftest.py
+++ b/ldapauthenticator/tests/conftest.py
@@ -5,7 +5,7 @@ import pytest
 from ..ldapauthenticator import LDAPAuthenticator
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture()
 def authenticator():
     authenticator = LDAPAuthenticator()
     authenticator.server_address = os.environ.get("LDAP_HOST", "localhost")

--- a/ldapauthenticator/tests/test_ldapauthenticator.py
+++ b/ldapauthenticator/tests/test_ldapauthenticator.py
@@ -75,7 +75,6 @@ async def test_ldap_auth_use_lookup_dn(authenticator):
         None, {"username": "fry", "password": "fry"}
     )
     assert authorized["name"] == "philip j. fry"
-    authenticator.use_lookup_dn_username = False
 
 
 async def test_ldap_auth_search_filter(authenticator):

--- a/ldapauthenticator/tests/test_ldapauthenticator.py
+++ b/ldapauthenticator/tests/test_ldapauthenticator.py
@@ -1,4 +1,9 @@
-# Inspired by https://github.com/jupyterhub/jupyterhub/blob/main/jupyterhub/tests/test_auth.py
+"""
+Inspired by https://github.com/jupyterhub/jupyterhub/blob/main/jupyterhub/tests/test_auth.py
+
+Testing data is hardcoded in docker-test-openldap, described at
+https://github.com/rroemhild/docker-test-openldap?tab=readme-ov-file#ldap-structure
+"""
 
 
 async def test_ldap_auth_allowed(authenticator):


### PR DESCRIPTION
By re-using the authenticator fixture, I think it could end up configured by one test influencing another, which added complexity that wasn't merited as initializing the LDAPAuthenticator class is trivial.