### PR TITLE
Require ldap3 2.9.1+ released 2021 (currently latest) as a lower bound

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     python_requires=">=3.9",
     install_requires=[
         "jupyterhub>=4.1.6",
-        "ldap3",
+        "ldap3>=2.9.1",
         "traitlets",
     ],
     extras_require={


### PR DESCRIPTION
By introducing a lower bounded version for the ldap3 dependency, future maintenance could become easier as its clear whats meant to be supported. With this, it becomes possible to introduce tests against the oldest supported dependencies etc.

![image](https://github.com/user-attachments/assets/bd0586a9-f0bc-4598-af97-76888c59dd71)
