### PR TITLE
Add `tls_strategy` and deprecate `use_ssl`

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,15 +167,35 @@ is what most shell username validators do.
 
 #### `LDAPAuthenticator.use_ssl`
 
-Boolean to specify whether to use SSL encryption when contacting
-the LDAP server. If it is left to `False` (the default)
-`LDAPAuthenticator` will try to upgrade connection with StartTLS.
-Set this to be `True` to start SSL connection.
+`use_ssl` is deprecated since 2.0. `use_ssl=True` translates to configuring
+`tls_strategy="on_connect"`, but `use_ssl=False` (previous default) doesn't
+translate to anything.
+
+#### `LDAPAuthenticator.tls_strategy`
+
+When LDAPAuthenticator connects to the LDAP server, it can establish a
+SSL/TLS connection directly, or do it before binding, which is LDAP
+terminology for authenticating and sending sensitive credentials.
+
+The LDAP v3 protocol deprecated establishing a SSL/TLS connection
+directly (`tls_strategy="on_connect"`) in favor of upgrading the
+connection to SSL/TLS before binding (`tls_strategy="before_bind"`).
+
+Supported `tls_strategy` values are:
+
+- "before_bind" (default)
+- "on_connect" (deprecated in LDAP v3, associated with use of port 636)
+- "insecure"
+
+When configuring `tls_strategy="on_connect"`, the default value of
+`server_port` becomes 636.
 
 #### `LDAPAuthenticator.server_port`
 
-Port to use to contact the LDAP server. Defaults to 389 if no SSL
-is being used, and 636 is SSL is being used.
+Port on which to contact the LDAP server.
+
+Defaults to `636` if `tls_strategy="on_connect"` is set, `389`
+otherwise.
 
 #### `LDAPAuthenticator.user_search_base`
 

--- a/ldapauthenticator/ldapauthenticator.py
+++ b/ldapauthenticator/ldapauthenticator.py
@@ -365,6 +365,11 @@ class LDAPAuthenticator(Authenticator):
         return (user_dn, response[0]["dn"])
 
     def get_connection(self, userdn, password):
+        """
+        Returns a ldap3 Connection object automatically bound to the user.
+
+        ldap3 Connection ref: https://ldap3.readthedocs.io/en/latest/connection.html
+        """
         if self.tls_strategy == TlsStrategy.on_connect:
             use_ssl = True
             auto_bind = ldap3.AUTO_BIND_NO_TLS

--- a/ldapauthenticator/tests/test_ldapauthenticator.py
+++ b/ldapauthenticator/tests/test_ldapauthenticator.py
@@ -5,6 +5,8 @@ Testing data is hardcoded in docker-test-openldap, described at
 https://github.com/rroemhild/docker-test-openldap?tab=readme-ov-file#ldap-structure
 """
 
+from ..ldapauthenticator import TlsStrategy
+
 
 async def test_ldap_auth_allowed(authenticator):
     # proper username and password in allowed group
@@ -56,14 +58,13 @@ async def test_ldap_auth_blank_template(authenticator):
     assert authorized["name"] == "fry"
 
 
-async def test_ldap_auth_ssl(authenticator):
-    authenticator.use_ssl = True
+async def test_ldap_use_ssl_deprecation(authenticator):
+    assert authenticator.tls_strategy == TlsStrategy.before_bind
 
-    # proper username and password in allowed group
-    authorized = await authenticator.get_authenticated_user(
-        None, {"username": "fry", "password": "fry"}
-    )
-    assert authorized["name"] == "fry"
+    # setting use_ssl to True should result in tls_strategy being set to
+    # on_connect
+    authenticator.use_ssl = True
+    assert authenticator.tls_strategy == TlsStrategy.on_connect
 
 
 async def test_ldap_auth_tls_strategy_on_connect(authenticator):

--- a/ldapauthenticator/tests/test_ldapauthenticator.py
+++ b/ldapauthenticator/tests/test_ldapauthenticator.py
@@ -58,7 +58,26 @@ async def test_ldap_auth_blank_template(authenticator):
 
 async def test_ldap_auth_ssl(authenticator):
     authenticator.use_ssl = True
-    authenticator.server_port = 636
+
+    # proper username and password in allowed group
+    authorized = await authenticator.get_authenticated_user(
+        None, {"username": "fry", "password": "fry"}
+    )
+    assert authorized["name"] == "fry"
+
+
+async def test_ldap_auth_tls_strategy_on_connect(authenticator):
+    authenticator.tls_strategy = "on_connect"
+
+    # proper username and password in allowed group
+    authorized = await authenticator.get_authenticated_user(
+        None, {"username": "fry", "password": "fry"}
+    )
+    assert authorized["name"] == "fry"
+
+
+async def test_ldap_auth_tls_strategy_insecure(authenticator):
+    authenticator.tls_strategy = "insecure"
 
     # proper username and password in allowed group
     authorized = await authenticator.get_authenticated_user(

--- a/ldapauthenticator/tests/test_ldapauthenticator.py
+++ b/ldapauthenticator/tests/test_ldapauthenticator.py
@@ -67,6 +67,10 @@ async def test_ldap_auth_ssl(authenticator):
 
 
 async def test_ldap_auth_tls_strategy_on_connect(authenticator):
+    """
+    Verifies basic function of the authenticator with a given tls_strategy
+    without actually confirming use of that strategy.
+    """
     authenticator.tls_strategy = "on_connect"
 
     # proper username and password in allowed group
@@ -77,6 +81,10 @@ async def test_ldap_auth_tls_strategy_on_connect(authenticator):
 
 
 async def test_ldap_auth_tls_strategy_insecure(authenticator):
+    """
+    Verifies basic function of the authenticator with a given tls_strategy
+    without actually confirming use of that strategy.
+    """
     authenticator.tls_strategy = "insecure"
 
     # proper username and password in allowed group


### PR DESCRIPTION
With `tls_strategy` we have three choices on how to secure our connection to the LDAP server. B

- "on_connect", it is "use_ssl=True" implied
- "before_bind", it is what "use_ssl=False" implied
- "insecure", this wasn't an option before, but has been requested by users.

---

- closes #216, as introduction of `tls_strategy="insecure"` can disable SSL/TLS entirely, which was the purpose of the new config.
- Thanks to `tls_strategy="insecure"` being available:
  - Fixes #241
  - Fixes #231
  - Fixes #211
  - Fixes #204
  - Fixes #179
