### PR TITLE
Change `use_lookup_dn_username` default value to False

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,9 +293,16 @@ If found, these will be available as `auth_state["user_attributes"]`.
 
 Only used with `lookup_dn=True`.
 
-If configured True (default value), the `lookup_dn_user_dn_attribute`
-value used to build the LDAP user's DN string is also used as the
-authenticated user's JuptyerHub username.
+If configured True, the `lookup_dn_user_dn_attribute` value used to
+build the LDAP user's DN string is also used as the authenticated user's
+JuptyerHub username.
+
+If this is configured True, its important to ensure that the values of
+`lookup_dn_user_dn_attribute` are unique even after the are normalized
+to be lowercase, otherwise two LDAP users could end up sharing the same
+JupyterHub username.
+
+With ldapauthenticator 2, the default value was changed to False.
 
 #### `LDAPAuthenticator.search_filter`
 

--- a/ldapauthenticator/ldapauthenticator.py
+++ b/ldapauthenticator/ldapauthenticator.py
@@ -391,14 +391,21 @@ class LDAPAuthenticator(Authenticator):
     )
 
     use_lookup_dn_username = Bool(
-        True,
+        False,
         config=True,
         help="""
         Only used with `lookup_dn=True`.
 
-        If configured True (default value), the `lookup_dn_user_dn_attribute`
-        value used to build the LDAP user's DN string is also used as the
-        authenticated user's JuptyerHub username.
+        If configured True, the `lookup_dn_user_dn_attribute` value used to
+        build the LDAP user's DN string is also used as the authenticated user's
+        JuptyerHub username.
+
+        If this is configured True, its important to ensure that the values of
+        `lookup_dn_user_dn_attribute` are unique even after the are normalized
+        to be lowercase, otherwise two LDAP users could end up sharing the same
+        JupyterHub username.
+
+        With ldapauthenticator 2, the default value was changed to False.
         """,
     )
 

--- a/ldapauthenticator/tests/conftest.py
+++ b/ldapauthenticator/tests/conftest.py
@@ -19,7 +19,6 @@ def c():
     c.LDAPAuthenticator.user_attribute = "uid"
     c.LDAPAuthenticator.lookup_dn_user_dn_attribute = "cn"
     c.LDAPAuthenticator.attributes = ["uid", "cn", "mail", "ou"]
-    c.LDAPAuthenticator.use_lookup_dn_username = False
 
     c.LDAPAuthenticator.allowed_groups = [
         "cn=admin_staff,ou=people,dc=planetexpress,dc=com",


### PR DESCRIPTION
This default change (only relevant if `lookup_dn=True`) makes JupyterHub usernames end up what was entered into the login form, as compared to end up what was looked up from a found user's value of the attribute which name was configured via `use_lookup_dn_username`.

In practice, this can be the difference between getting JupyterHub usernames like `philip j. fry` (normalized from `Philips J. Fry`) and `fry` when entering the username `fry` when logging in.

I propose this breaking change because:
- I think its more intuitive behavior to have users with the username they write when logging in
- It would make toggling between using `bind_dn_template` to `lookup_dn` configs less likely to change existing jupyterhub users' usernames.
- I think its less risky from a security perspective, as the usernames provided in the login form are checked to be lowercase for example, and that means jupyterhub's normalization of usernames wont change much later, which means that a single username given in the login form becomes guaranteed unique no matter if LDAP is case sensitive or not etc. We want to avoid multiple users get overlapping jupyterhub account names, as possibly could happen after normalization of something picked via a lookup based on the login forms username.
  Overall, I'm not sure if there is a security risk or not related to this, but since I've not ruled it out I figure this is the safer default.