### PR TITLE
tests: pass config to constructor instead of configuring after

### DIFF
--- a/ldapauthenticator/tests/conftest.py
+++ b/ldapauthenticator/tests/conftest.py
@@ -1,25 +1,29 @@
 import os
 
 import pytest
-
-from ..ldapauthenticator import LDAPAuthenticator
+from traitlets.config import Config
 
 
 @pytest.fixture()
-def authenticator():
-    authenticator = LDAPAuthenticator()
-    authenticator.server_address = os.environ.get("LDAP_HOST", "localhost")
-    authenticator.lookup_dn = True
-    authenticator.bind_dn_template = "cn={username},ou=people,dc=planetexpress,dc=com"
-    authenticator.user_search_base = "ou=people,dc=planetexpress,dc=com"
-    authenticator.user_attribute = "uid"
-    authenticator.lookup_dn_user_dn_attribute = "cn"
-    authenticator.attributes = ["uid", "cn", "mail", "ou"]
-    authenticator.use_lookup_dn_username = False
+def c():
+    """
+    A base configuration for LDAPAuthenticator that individual tests can adjust.
+    """
+    c = Config()
+    c.LDAPAuthenticator.server_address = os.environ.get("LDAP_HOST", "localhost")
+    c.LDAPAuthenticator.lookup_dn = True
+    c.LDAPAuthenticator.bind_dn_template = (
+        "cn={username},ou=people,dc=planetexpress,dc=com"
+    )
+    c.LDAPAuthenticator.user_search_base = "ou=people,dc=planetexpress,dc=com"
+    c.LDAPAuthenticator.user_attribute = "uid"
+    c.LDAPAuthenticator.lookup_dn_user_dn_attribute = "cn"
+    c.LDAPAuthenticator.attributes = ["uid", "cn", "mail", "ou"]
+    c.LDAPAuthenticator.use_lookup_dn_username = False
 
-    authenticator.allowed_groups = [
+    c.LDAPAuthenticator.allowed_groups = [
         "cn=admin_staff,ou=people,dc=planetexpress,dc=com",
         "cn=ship_crew,ou=people,dc=planetexpress,dc=com",
     ]
 
-    return authenticator
+    return c


### PR DESCRIPTION
Our tests previously was written in a way what created a blank authenticator object, and then configured it one config at the time. I want to transition away from that, as it makes traitlets verification of config error if any of the incremental configuration steps after the authenticator object is initialized are invalid - even though the final configuration won't be.

By this change, we align better with how users are going to use their authentication class which is typically initialized by jupyterhub itself based on config provided, rather than initialized without provided config and then updated.