### PR TITLE
fix: Ensure a list `bind_dn_template` is properly validated

### DIFF
--- a/ldapauthenticator/ldapauthenticator.py
+++ b/ldapauthenticator/ldapauthenticator.py
@@ -150,7 +150,7 @@ class LDAPAuthenticator(Authenticator):
         rv = []
         if isinstance(proposal.value, str):
             rv = [proposal.value]
-        elif isinstance(proposal.value, list):
+        else:
             rv = proposal.value
         if "" in rv:
             self.log.warning("Ignoring blank 'bind_dn_template' entry!")

--- a/ldapauthenticator/ldapauthenticator.py
+++ b/ldapauthenticator/ldapauthenticator.py
@@ -150,6 +150,8 @@ class LDAPAuthenticator(Authenticator):
         rv = []
         if isinstance(proposal.value, str):
             rv = [proposal.value]
+        elif isinstance(proposal.value, list):
+            rv = proposal.value
         if "" in rv:
             self.log.warning("Ignoring blank 'bind_dn_template' entry!")
             rv = [e for e in rv if e]


### PR DESCRIPTION
Seems like we are ignoring the value of `bind_dn_template` when it is a string in validator. This PR fixes it by checking if value is of list instance and setting up the value correctly.