### PR TITLE
Fix parsing of search response

### DIFF
--- a/ldapauthenticator/ldapauthenticator.py
+++ b/ldapauthenticator/ldapauthenticator.py
@@ -542,7 +542,6 @@ class LDAPAuthenticator(Authenticator):
             return conn
 
     def get_user_attributes(self, conn, userdn):
-        attrs = {}
         if self.auth_state_attributes:
             conn.search(
                 search_base=userdn,
@@ -554,13 +553,13 @@ class LDAPAuthenticator(Authenticator):
             # identify unique search response entry
             n_entries = len(conn.entries)
             if n_entries == 1:
-                attrs = conn.entries[0].entry_attributes_as_dict
+                return conn.entries[0].entry_attributes_as_dict
             else:
                 self.log.warning(
                     f"Expected 1 but got {n_entries} search response entries for DN '{userdn}' "
                     "when looking up attributes configured via auth_state_attributes."
                 )
-        return attrs
+        return {}
 
     async def authenticate(self, handler, data):
         """

--- a/ldapauthenticator/ldapauthenticator.py
+++ b/ldapauthenticator/ldapauthenticator.py
@@ -464,7 +464,7 @@ class LDAPAuthenticator(Authenticator):
             )
             return (None, None)
         if n_entries > 1:
-            self.log.warning(
+            self.log.error(
                 f"Failed to lookup a unique DN for username '{username_supplied_by_user}'"
             )
             return (None, None)

--- a/ldapauthenticator/ldapauthenticator.py
+++ b/ldapauthenticator/ldapauthenticator.py
@@ -477,16 +477,17 @@ class LDAPAuthenticator(Authenticator):
             self.lookup_dn_user_dn_attribute
         )
         if not attribute_values:
-            self.log.warning(
-                f"Failed to lookup attribute '{self.lookup_dn_user_dn_attribute}' "
-                f"for username '{username_supplied_by_user}'"
+            self.log.error(
+                f"Login of '{username_supplied_by_user}' denied, failed to lookup attribute "
+                f"'{self.lookup_dn_user_dn_attribute}'. Is lookup_dn_user_dn_attribute "
+                "configured correctly?"
             )
             return (None, None)
         if len(attribute_values) > 1:
             self.log.error(
-                f"A lookup of the username '{username_supplied_by_user}' returned multiple "
-                f"values for the attribute '{self.lookup_dn_user_dn_attribute}': "
-                f"({', '.join(attribute_values)})"
+                f"Login of '{username_supplied_by_user}' denied, lookup of attribute "
+                f"'{self.lookup_dn_user_dn_attribute}' gave multiple values but only "
+                "one is expected. Is lookup_dn_user_dn_attribute configured correctly?"
             )
             return None, None
 


### PR DESCRIPTION
Fixes #292 and a bug that maybe never surfaced where things could work before 2.0.0 when the conn.response list had multiple elements thanks to being ordered in a way where the first element was the one of relevance, even though [LDAP specification sais](https://datatracker.ietf.org/doc/html/rfc4511#section-4.5.2) any ordering is allowed. Maybe the ldap3 client orders them, but who knows.

Also fixes #295

### Investigation

- Should we use [conn.entries](https://ldap3.readthedocs.io/en/latest/searches.html#entries) instead of [conn.response](https://ldap3.readthedocs.io/en/latest/searches.html#response)? How is conn.entries populated? Is it the `type=searchResEntry` responses?
    Answer: yes we should use conn.entries, it is only including `type=searchResEntry` responses, see the [code here](https://github.com/cannatag/ldap3/blob/v2.9.1/ldap3/core/connection.py#L1555-L1603).

### References
- discussion: https://github.com/jupyterhub/ldapauthenticator/issues/292
- ldap3 docs: https://ldap3.readthedocs.io/en/latest/searches.html#entries
- LDAP docs:  https://datatracker.ietf.org/doc/html/rfc4511#section-4.5.2
