### PR TITLE
Fix: prevent [None] being passed to LDAP search attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,6 @@ See [our definition of contributors](https://github-activity.readthedocs.io/en/l
 - `lookup_dn` now rejects an authenticating user if multiple DNs are returned
   during lookup. ([#276](https://github.com/jupyterhub/ldapauthenticator/pull/276))
 - In the edge case if both...
-
   1. the following config is used:
      - `lookup_dn = True`,
      - `lookup_dn_user_dn_attribute = "cn"`

--- a/ldapauthenticator/ldapauthenticator.py
+++ b/ldapauthenticator/ldapauthenticator.py
@@ -453,7 +453,11 @@ class LDAPAuthenticator(Authenticator):
             search_base=self.user_search_base,
             search_scope=ldap3.SUBTREE,
             search_filter=search_filter,
-            attributes=[self.lookup_dn_user_dn_attribute] if self.lookup_dn_user_dn_attribute else ldap3.ALL_ATTRIBUTES,
+            attributes=(
+                [self.lookup_dn_user_dn_attribute]
+                if self.lookup_dn_user_dn_attribute
+                else ldap3.ALL_ATTRIBUTES
+            ),
         )
 
         # identify unique search response entry


### PR DESCRIPTION
This PR fixes a bug in `_resolve_username_dn()` where `attributes=[self.lookup_dn_user_dn_attribute]` could result in `[None]` being passed to `conn.search()`, which raises a `TypeError`.

**Before:**
```python
attributes=[self.lookup_dn_user_dn_attribute]  # if None → [None]
```
**After:**
```python
attributes=[self.lookup_dn_user_dn_attribute] if self.lookup_dn_user_dn_attribute else ldap3.ALL_ATTRIBUTES
```
**Fixes:** 
```
TypeError: argument of type 'NoneType' is not iterable when lookup_dn_user_dn_attribute is unset.
```
